### PR TITLE
proxy無効化

### DIFF
--- a/knet/knet.go
+++ b/knet/knet.go
@@ -5,10 +5,12 @@ import (
 	"golang.org/x/net/publicsuffix"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
 	"strings"
+	"time"
 )
 
 const NetworkError = "Network Error"
@@ -43,6 +45,17 @@ func Login(uid string, pass string) error {
 	}
 
 	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+				DualStack: true,
+			}).DialContext,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
 		Jar: jar,
 	}
 
@@ -107,4 +120,3 @@ func formParser(form *goquery.Selection) (string, url.Values, bool) { //エラ�
 	})
 	return postUrl, data, false
 }
-


### PR DESCRIPTION
`http.Client`に渡すhttp.TransportにProxyを利用しないように設定した。